### PR TITLE
Remove "RUN apt-get update" from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM openjdk:8-jdk as build
 
-RUN apt-get update
 COPY . /project
 WORKDIR /project
 RUN ./gradlew build -x test


### PR DESCRIPTION
Because that alone (without upgrade) does nothing; we don't need this.