### PR TITLE
Fix the classpath mess

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -43,11 +43,6 @@ ext {
 }
 
 dependencies {
-    // just for mapping our enums to catalog types,
-    // but this is an implementation detail; users of this API won't directly use spongeapi themselves
-    // TODO remove this again, and move enum mapping into impl instead of API...
-    implementation 'org.spongepowered:spongeapi:7.3.0'
-
     compile "io.vertx:vertx-core:$vertxVersion"
     compile "io.vertx:vertx-web:$vertxVersion"
     compile "io.vertx:vertx-auth-jwt:$vertxVersion"
@@ -58,6 +53,7 @@ dependencies {
     annotationProcessor "io.vertx:vertx-service-proxy:$vertxVersion"
 
     testCompile "io.vertx:vertx-unit:$vertxVersion"
+    testCompile project(':test-utils')
 }
 
 eclipse {

--- a/api/src/test/java/ch/vorburger/minecraft/storeys/api/ClasspathHellDuplicatesCheckerTest.java
+++ b/api/src/test/java/ch/vorburger/minecraft/storeys/api/ClasspathHellDuplicatesCheckerTest.java
@@ -1,0 +1,29 @@
+/*
+ * ch.vorburger.minecraft.storeys
+ *
+ * Copyright (C) 2016 - 2018 Michael Vorburger.ch <mike@vorburger.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.vorburger.minecraft.storeys.api;
+
+import ch.vorburger.minecraft.storeys.testutils.ClasspathHellDuplicatesChecker;
+import org.junit.Test;
+
+public class ClasspathHellDuplicatesCheckerTest {
+
+    @Test public void testNoClasspathDuplicates() {
+        ClasspathHellDuplicatesChecker.check();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ plugins {
 }
 
 repositories {
-    // mavenLocal()
     jcenter()
 }
 
@@ -50,7 +49,6 @@ subprojects {
     apply plugin: 'biz.aQute.bnd.builder'
 
     repositories {
-        mavenLocal() // for ch.vorburger.minecraft.osgi.api
         jcenter()
         maven {
             name = 'sponge'
@@ -62,11 +60,22 @@ subprojects {
         // errorprone 'com.google.errorprone:error_prone_core:2.3.1'
         // implementation 'com.google.errorprone:error_prone_annotations:2.3.1'
 
-        implementation 'org.spongepowered:spongeapi:7.3.0'
+        implementation('org.spongepowered:spongeapi:7.3.0') {
+            exclude group: 'com.google.guava'
+            exclude group: 'com.google.inject'
+            exclude group: 'com.google.code.gson'
+            exclude group: 'commons-lang3'
+        }
+        implementation 'com.google.guava:guava:31.1-jre'
+        implementation 'com.google.inject:guice:4.2.3'
+        implementation 'com.google.code.gson:gson:2.9.0'
+        implementation 'org.apache.commons:commons-lang3:3.12.0'
+
+        implementation 'org.slf4j:slf4j-api:1.7.36'
+        testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'org.hamcrest:hamcrest-library:2.2'
-        testImplementation 'org.slf4j:slf4j-simple:1.7.30'
         testImplementation 'org.mockito:mockito-core:3.8.0'
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-include 'engine', 'api', 'storeys', 'web', 'scratch3'
+include 'test-utils', 'engine', 'api', 'storeys', 'web', 'scratch3'
 
 rootProject.name = 'minecraft-storeys-maker'

--- a/storeys/build.gradle
+++ b/storeys/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation('com.spotify:futures-extra:4.0.0') {
         exclude group: 'com.google.guava' 
     }
+    testCompile project(':test-utils')
 }
 
 shadowJar {

--- a/storeys/src/test/java/ch/vorburger/minecraft/storeys/tests/ClasspathHellDuplicatesCheckerTest.java
+++ b/storeys/src/test/java/ch/vorburger/minecraft/storeys/tests/ClasspathHellDuplicatesCheckerTest.java
@@ -1,0 +1,29 @@
+/*
+ * ch.vorburger.minecraft.storeys
+ *
+ * Copyright (C) 2016 - 2018 Michael Vorburger.ch <mike@vorburger.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.vorburger.minecraft.storeys.tests;
+
+import ch.vorburger.minecraft.storeys.testutils.ClasspathHellDuplicatesChecker;
+import org.junit.Test;
+
+public class ClasspathHellDuplicatesCheckerTest {
+
+    @Test public void testNoClasspathDuplicates() {
+        ClasspathHellDuplicatesChecker.check();
+    }
+}

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'io.github.classgraph:classgraph:4.8.143'
+    testImplementation 'junit:junit:4.13.2'
+}

--- a/test-utils/src/main/java/ch/vorburger/minecraft/storeys/testutils/ClasspathHellDuplicatesChecker.java
+++ b/test-utils/src/main/java/ch/vorburger/minecraft/storeys/testutils/ClasspathHellDuplicatesChecker.java
@@ -1,0 +1,55 @@
+/*
+ * ch.vorburger.minecraft.storeys
+ *
+ * Copyright (C) 2016 - 2018 Michael Vorburger.ch <mike@vorburger.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.vorburger.minecraft.storeys.testutils;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.Resource;
+import io.github.classgraph.ResourceList;
+import io.github.classgraph.ResourceList.ResourceFilter;
+import java.util.Map.Entry;
+
+/**
+ * See
+ * https://github.com/classgraph/classgraph/wiki/Code-examples#find-all-duplicate-class-definitions-in-the-classpath-or-module-path,
+ * inspired by
+ * https://github.com/opendaylight/infrautils/blob/ae405c37df3d62f78d3c482212534875eaba776d/testutils/src/main/java/org/opendaylight/infrautils/testutils/ClasspathHellDuplicatesChecker.java
+ */
+public class ClasspathHellDuplicatesChecker {
+
+    // Using this via "./gradlew test" and in an IDE such as Eclipse will not have the same classpath; so try both!! ;-(
+
+    private static final ResourceFilter EXCLUSIONS = resource -> !resource.getPath().endsWith("module-info.class")
+            && !resource.getURI().toString().contains(".gradle/wrapper");
+
+    public static void check() {
+        StringBuilder sb = new StringBuilder();
+        for (Entry<String, ResourceList> dup : new ClassGraph().scan().getAllResources().classFilesOnly().filter(EXCLUSIONS)
+                .findDuplicatePaths()) {
+            sb.append(dup.getKey() + "\n");
+            try (ResourceList value = dup.getValue()) {
+                for (Resource res : value) {
+                    sb.append(" -> " + res.getURI() + "\n");
+                }
+            }
+        }
+        if (sb.length() > 0) {
+            throw new AssertionError(sb.toString());
+        }
+    }
+}

--- a/test-utils/src/test/java/ch/vorburger/minecraft/storeys/testutils/ClasspathHellDuplicatesCheckerTest.java
+++ b/test-utils/src/test/java/ch/vorburger/minecraft/storeys/testutils/ClasspathHellDuplicatesCheckerTest.java
@@ -1,0 +1,28 @@
+/*
+ * ch.vorburger.minecraft.storeys
+ *
+ * Copyright (C) 2016 - 2018 Michael Vorburger.ch <mike@vorburger.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.vorburger.minecraft.storeys.testutils;
+
+import org.junit.Test;
+
+public class ClasspathHellDuplicatesCheckerTest {
+
+    @Test public void testNoClasspathDuplicates() {
+        ClasspathHellDuplicatesChecker.check();
+    }
+}

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -6,17 +6,32 @@ plugins {
 
 dependencies {
     implementation project(':api')
-    implementation project(':storeys')
+    implementation(project(':storeys')) {
+      // because this is already "shadowed" into the :storeys JAR
+      exclude group: 'com.spotify', module: 'futures-extra'
+      exclude group: 'ch.vorburger.minecraft.osgi', module: 'api'
+    }
     implementation project(':scratch3')
 
+    // compileOnly for what is "shadowed" into :storeys at runtime, but still needed at compile-time
+    compileOnly 'ch.vorburger.minecraft.osgi:api:1.0.0'
+
+    implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.osgi:org.osgi.core:6.0.0'
-    implementation 'ch.vorburger.minecraft.osgi:api:1.0.0'
-    implementation 'com.github.eirslett:frontend-plugin-core:1.8.0'
+    implementation('com.github.eirslett:frontend-plugin-core:1.8.0') {
+      // webdrivermanager has newer versions of all of these, and the Eclipse Gradle integration is too dumb to exclude the older one, so ClasspathHellDuplicatesCheckerTest fails without this in Eclipse (only, on ./gradlew test it passes, which is weird).
+      exclude group: 'commons-io'
+    }
 
     implementation 'io.vertx:vertx-service-proxy:4.0.2'
 
-    testCompile "org.seleniumhq.selenium:selenium-java:3.141.59"
-    testCompile 'io.github.bonigarcia:webdrivermanager:4.3.1'
+    testCompile 'org.seleniumhq.selenium:selenium-java:3.141.59'
+    testCompile('io.github.bonigarcia:webdrivermanager:4.3.1') {
+      exclude group: 'commons-io'
+      exclude group: 'commons-codec'
+      exclude group: 'org.apache.commons', module: 'commons-compress'
+    }
+    testCompile project(':test-utils')
 }
 
 task runWithJavaExec(type: JavaExec) {

--- a/web/src/test/java/ch/vorburger/minecraft/storeys/web/ClasspathHellDuplicatesCheckerTest.java
+++ b/web/src/test/java/ch/vorburger/minecraft/storeys/web/ClasspathHellDuplicatesCheckerTest.java
@@ -1,0 +1,29 @@
+/*
+ * ch.vorburger.minecraft.storeys
+ *
+ * Copyright (C) 2016 - 2018 Michael Vorburger.ch <mike@vorburger.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.vorburger.minecraft.storeys.web;
+
+import ch.vorburger.minecraft.storeys.testutils.ClasspathHellDuplicatesChecker;
+import org.junit.Test;
+
+public class ClasspathHellDuplicatesCheckerTest {
+
+    @Test public void testNoClasspathDuplicates() {
+        ClasspathHellDuplicatesChecker.check();
+    }
+}


### PR DESCRIPTION
@edewit this bring us a "clean" classpath again.

It was basically impossible to run the `SeleniumTest` in-IDE (Eclipse) for me anymore - now it nicely passes green again.

I have NOT yet tested this for side-effects "end to end" (in Minecraft) - perhaps you want to try this doesn't actually break anything, notably e.g. the `com.github.eirslett:frontend-plugin-core` NodeJS `NodeStarter` related stuff.