### PR TITLE
Add missing test coverage

### DIFF
--- a/storeys/src/test/java/ch/vorburger/minecraft/storeys/model/parser/StoryParserTest.java
+++ b/storeys/src/test/java/ch/vorburger/minecraft/storeys/model/parser/StoryParserTest.java
@@ -130,8 +130,12 @@ public class StoryParserTest {
 
         // then
         List<Action<?>> storyActionsList = story.getActionsList();
-        assertEquals(1, storyActionsList.size());
-        assertEquals(DynamicAction.class, storyActionsList.get(0).getClass());
+        assertEquals(5, storyActionsList.size());
+        assertEquals(MessageAction.class, storyActionsList.get(0).getClass());
+        assertEquals(NopAction.class, storyActionsList.get(1).getClass());
+        assertEquals(DynamicAction.class, storyActionsList.get(2).getClass());
+        assertEquals(NopAction.class, storyActionsList.get(3).getClass());
+        assertEquals(MessageAction.class, storyActionsList.get(4).getClass());
     }
 
     @Test public void parseMessage() throws IOException, SyntaxErrorException {

--- a/storeys/src/test/resources/dynamic-test.story
+++ b/storeys/src/test/resources/dynamic-test.story
@@ -1,5 +1,9 @@
+Hello!
+
   if (!player.inventory.contains(ItemTypes.FISHING_ROD)) {
     return 'There may be a fishing rod hidden somewhere… look for it, and then catch a fish!\n'
   } else {
     return 'Go fishing with the rod in your inventory..\n'
   }
+
+La fin.


### PR DESCRIPTION
While #332 fixed #301, it didn't actually add any non-regression test coverage for that; this adds that (using the reproducer from the bug).

@edewit makes sense - OK for you - merge this?