### PR TITLE
Add cloudbuild.yaml (re. #327)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+
+# -t gcr.io/oasis-learn-study/github.com/oasis-learn-study/minecraft-storeys-maker:$COMMIT_SHA


### PR DESCRIPTION
@edewit review and merge this?

This allows me to (later) customize our CI, so that instead of just running the `Dockerfile` I should be able to make it run `test` from #327.