### PR TITLE
Fix missing initial JS loading

### DIFF
--- a/api-jvm-impl/src/main/java/ch/vorburger/minecraft/storeys/japi/impl/Scripts.java
+++ b/api-jvm-impl/src/main/java/ch/vorburger/minecraft/storeys/japi/impl/Scripts.java
@@ -44,11 +44,13 @@ public class Scripts {
         script.init(e);
     }
 
-    public void unregister(Object key) {
+    public boolean unregister(Object key) {
         Unregisterable unregisterable = unregisterables.remove(key);
         if (unregisterable != null) {
             unregisterable.unregister();
+            return true;
         }
+        return false;
     }
 
     public Collection<Unregisterable> getUnregisterables() {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,7 +48,6 @@ The following doesn't work yet, but should after bug #310 is resolved:
 
 ## JavaScript (v3, `new-scripts/*.js`)
 
-1. `touch minecraft-server-test-data/config/storeys-web/new-scripts/test.js` _(TODO this won't be required anymore in the future)_
 1. `/new`
 1. Verify [`test.js`](../minecraft-server-test-data/config/storeys-web/new-scripts/test.js) happened as expected
 1. Edit `test.js` to change `m.title("Hello");` to `m.title("hello, world");`

--- a/storeys/build.gradle
+++ b/storeys/build.gradle
@@ -1,8 +1,13 @@
 
+repositories {
+    mavenCentral()
+    // mavenLocal() // un-comment temporarily for local dev (only)
+}
+
 dependencies {
     api project(':api-jvm-impl')
     api 'ch.vorburger.minecraft.osgi:api:1.0.0'
-    implementation 'ch.vorburger:fswatch:1.2.0'
+    implementation 'ch.vorburger:fswatch:1.3.0'
 
     implementation project(':example')
     testImplementation project(':test-utils')

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
+repositories {
+    mavenCentral()
+    // mavenLocal() // un-comment temporarily for local dev (only)
+}
+
 dependencies {
     implementation project(':api')
     implementation(project(':storeys'))


### PR DESCRIPTION
**TODO**
1. rebase 
1. local testing
1. deploy new version of `fswatch` to Maven central
1. remove `mavenLocal()` (x2)
1. remove `-SNAPSHOT` of `fswatch`
1. local re-testing
1. undraft
1. @edewit testing, review and merge

This complements #310.