### PR TITLE
Downgrade JDK from 11 to 8 in Dockerfile-build

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk as build
+FROM openjdk:8-jdk as build
 
 # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
 RUN curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && apt install -y nodejs && node --version


### PR DESCRIPTION
instead of #394

This will be tested through #382.