### PR TITLE
Use docker.io[/library] prefix for container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:java8-multiarch
+FROM docker.io/itzg/minecraft-server:java8-multiarch
 
 # RUN mkdir /mods/ && cd /mods/ && curl -sS -L -J -f -O https://github.com/OASIS-learn-study/swissarmyknife-minecraft-server-binaries/raw/master/LuckPerms-Sponge-5.3.98.jar
 

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk as build
+FROM docker.io/library/openjdk:11-jdk as build
 
 # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
 RUN curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && apt install -y nodejs && node --version


### PR DESCRIPTION
This avoids two annoying interactive prompts during the `./test` build, which ask me which registry to pull the JDK image from (Docker Hub VS those RH's), on my fresh Silverblue install.

@edewit OK for you (if our CI build passes) and do you want to merge?