### PR TITLE
Revert "Improved timeout handling"

### DIFF
--- a/test-mineflayer/storeys.test.js
+++ b/test-mineflayer/storeys.test.js
@@ -13,42 +13,46 @@ const createBot = (command) => {
   return bot;
 }
 
-describe("Storeys plugin test", () => {
-  let bot;
+const handleError = (bot, done) => {
+  bot.on("error", (e) => {
+    done(e);
+  });
+}
 
-  const handleError = (done) => {
-    bot.on("error", (e) => {
-      done(e);
-    });
-  }
-  
-  afterEach(() => bot.quit());
+describe("Storeys plugin test", () => {
+  beforeAll(() => {
+    // Prevent jest from complaining about an import after the test is done (You are trying to `import` a file after the Jest environment has been torn down.)
+    jest.useFakeTimers('legacy');
+    console.log = () => { };
+  });
 
   test("should connect to minecraft server and execute /make", (done) => {
     // given
-    bot = createBot("/make");
+    const bot = createBot("/make");
 
     // then
     bot.on('messagestr', (msg) => {
       if (msg !== "Player joined the game") {
         expect(msg).toEqual("Click here to open Scratch and MAKE actions");
         done();
+        bot.quit();
       }
     });
 
-    handleError(done);
+    handleError(bot, done);
   }, TIMEOUT);
 
   test("should execute /new", (done) => {
     // given
-    bot = createBot("/new");
+    const bot = createBot("/new");
 
     // then
     bot.on('title', (msg) => {
       expect(msg).toEqual("{\"text\":\"Hello\"}");
       done();
+      bot.quit();
     });
 
-    handleError(done);
+    handleError(bot, done);
   }, TIMEOUT);
 });


### PR DESCRIPTION
Reverts OASIS-learn-study/minecraft-storeys-maker#410, because builds fail (on GCB) since this.